### PR TITLE
fix: 카카오 로그인시 토큰 파싱

### DIFF
--- a/lib/hooks/login/loginscreen.dart
+++ b/lib/hooks/login/loginscreen.dart
@@ -118,9 +118,8 @@ Future<void> _login() async {
           final Map<String, dynamic> responseBody = jsonDecode(response.body);
 
           // 서버로부터 받은 accessToken 저장
-          if (responseBody.containsKey('result') &&
-              responseBody['result'].containsKey('accessToken')) {
-            _accessToken = responseBody['result']['accessToken'];
+          if (responseBody.containsKey('result')){
+            _accessToken = responseBody['result'];
             await _storageService.write(
                 key: 'accessToken', value: _accessToken!); // Secure Storage에 저장
             print('Access Token: $_accessToken'); // 디버깅용


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified logic for extracting and storing the access token from server responses, improving reliability in handling variations in the response structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->